### PR TITLE
expose client on rnodeService

### DIFF
--- a/src/rnode-grpc.js
+++ b/src/rnode-grpc.js
@@ -249,10 +249,11 @@ export const rnodeService = (options) => {
   const protocol = makeGrpcProtocol(options)
 
   // Create RNode service API from proto definition
-  return R.mapObjIndexed(
-    createApiMethod({...options, protocol}, getType),
+  const service = R.mapObjIndexed(
+    createApiMethod({ ...options, protocol }, getType),
     methods,
   )
+  return { ...service, _grpcClient: protocol.client }
 }
 
 // Different name for each service to support TypeScript definitions


### PR DESCRIPTION
For a long run application, sometimes people want to get to control the life of the client(channel). Right now, people can open the client with the server but have no ideas how to close the client.

By exposing the client, people can control the life of the channel like closing the channle by

```
client.close() or grpc.closeClient(client)
```